### PR TITLE
fix: typo in cf "Language: English Only"

### DIFF
--- a/GERMAN_DUAL_LANGUAGE_GUIDE_GER.md
+++ b/GERMAN_DUAL_LANGUAGE_GUIDE_GER.md
@@ -238,7 +238,7 @@ Importiere das Custom Format "Language: English Only":
 
 ```json
 {
-  "name": " Language: English Only",
+  "name": "Language: English Only",
   "includeCustomFormatWhenRenaming": false,
   "specifications": [
     {

--- a/README.md
+++ b/README.md
@@ -244,7 +244,7 @@ Import the Custom Format "Language: English Only":
 
 ```json
 {
-  "name": " Language: English Only",
+  "name": "Language: English Only",
   "includeCustomFormatWhenRenaming": false,
   "specifications": [
     {


### PR DESCRIPTION
The custom format's name for "Language: English Only" contained a space in the beginning which lead to a wrong sorting (position in the UI).